### PR TITLE
Remove libVersion

### DIFF
--- a/achievements/achievements.lua
+++ b/achievements/achievements.lua
@@ -31,7 +31,6 @@
 ---@field gameID string A unique ID to identify the game. Analogous to BundleID in pdxinfo.
 ---@field version string The version string of the game, as in pdxinfo.
 ---@field specVersion string The version string of the specification used.
----@field libVersion string The version string of the Achievement library used.
 ---@field defaultIcon string | nil The filepath for the game's default unlocked achievement icon, relative to the value of achievements.imagePath.
 ---@field defaultIconLocked string | nil The filepath for the game's default locked achievement icon, relative to the value of achievements.imagePath.
 ---@field secretIcon string | nil The filepath for the game's 'hidden achievement' icon.
@@ -62,7 +61,6 @@ local shared_images_updated_file <const> = "_last_seen_version.txt"
 ---@diagnostic disable-next-line: lowercase-global
 achievements = {
 	specVersion = "0.2",
-	libVersion = "0.3-alpha",
 	flag_is_playdatesquad_api = true,
 
 	forceSaveOnGrantOrRevoke = false,
@@ -263,10 +261,8 @@ local function validate_gamedata(ach_root, prevent_debug)
 	end
 
 	ach_root.specVersion = achievements.specVersion
-	ach_root.libVersion = achievements.libVersion
 	print("game version saved as \"" .. ach_root.version .. "\"")
 	print("specification version saved as \"" .. ach_root.specVersion .. "\"")
-	print("library version saved as \"" .. ach_root.libVersion .. "\"")
 
 	if type(ach_root.defaultIcon) ~= 'string' and ach_root.defaultIcon ~= nil then
 		error("expected 'defaultIcon' to be type string, got " .. type(ach_root.defaultIconcon), 3)

--- a/achievements/crossgame.lua
+++ b/achievements/crossgame.lua
@@ -32,7 +32,7 @@ crossgame.getData = function(game_id)
 	end
 	local data = json.decodeFile(achievements.paths.get_achievement_data_file_path(game_id))
 	-- Quick sanity check...
-	if not (data.libVersion and data.specVersion) then
+	if not data.specVersion then
 		return false, "Achievement file was found but not valid."
 	end
 	local completion_total = 0

--- a/test_game/generate_data.lua
+++ b/test_game/generate_data.lua
@@ -27,7 +27,6 @@ function generate_game_data(numgames, achievements_min, achievements_max)
             description = "Auto-generated random game data for achievement viewer testing. (#" .. i ..")",
             version = "0.0.0",
             specVersion = achievements.specVersion,
-            libVersion = achievements.libVersion,
             achievements = {},
         }
         -- Begin generating achievement data.


### PR DESCRIPTION
Removes the **libVersion** key from achievement data generation and checking.

Authors and viewers should instead rely on **specVersion** to determine compatibility.