### PR TITLE
README improvements for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The included Lua reference library provides three components:
 All of these components are optional—you can implement or omit any of these in the way that works best for your game.
 
 > [!NOTE]
-> If your game is not written in Lua you can still support Playdate Achievements. However, you'll need to reference the [schema](achievements.schema.json) and write your achievement data directly to the `/Shared` folder at the path `/Shared/Achievements/[gameID]/Achievements.json`, using a unique ID for your game (such as its bundle ID).
+> If your game is not written in Lua you can still support Playdate Achievements. However, you'll need to reference the [schema](achievements.schema.json) and write your achievement data directly to the `/Shared` folder at the path `/Shared/Achievements/[gameID]/Achievements.json`, where `gameID` is the same as the gameID you specify in achievements.json.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository provides two things:
 The Lua library makes it easy to support playdate achievements in your games, providing APIs to configure and grant achievements, then save them in the appropriate format. It also comes with limited in-game achievement viewer and toast notification implementations. Developers are welcome to use it out-of-the-box, though we also encourage custom viewers both in-game and as 3rd party on-device viewer apps.
 
 > [!NOTE]
-> If your game is not written in Lua you can still support Playdate Achievements. However, you'll need to reference the [schema](achievements.schema.json) and write your achievement data directly to the `/Shared` folder at the path `/Shared/Achievements/[gameID]`, using a unique ID for your game (such as its bundle ID).
+> If your game is not written in Lua you can still support Playdate Achievements. However, you'll need to reference the [schema](achievements.schema.json) and write your achievement data directly to the `/Shared` folder at the path `/Shared/Achievements/[gameID]/Achievements.json`, using a unique ID for your game (such as its bundle ID).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,43 @@
-# pd-achievements
-Cross-game achievement standard for the Playdate console.
+# 🏆 pd-achievements
 
-Useful for configuring, granting, and revoking in-game achievements. Comes with some limited achievement viewing support out-of-the-box, but developers are encouraged to create their own 3rd party clients for viewing achievements on-device.
+_An open achievement standard for the Playdate console_
 
-WARNING: This standard is still in development. Forward-compatibility is not yet guaranteed.
+Playdate Achievements is a community project establishing an open standard for achievements in Playdate™ games. Having a standard ensures a consistent experience for players, and makes it possible to view achievements earned across games in one place.
 
-[The specification draft can be seen here.](https://docs.google.com/document/d/15iYMDmXdnDbOhoskyvfJsypu7Ls538R0kJNVYKDFx44/edit#heading=h.387me39epg7l)
+This repository provides two things:
+
+1. **Achievements Schema:** A [schema](achievements.schema.json) describing the open Playdate Achievements data storage format which _any_ game may use to adopt the standard.
+2. **Lua Achievements Library:** A Lua library that games may use to implement the schema, along with UI niceties for displaying toast notifications and an in-game achievements viewer.
+
+The Lua library makes it easy to support playdate achievements in your games, providing APIs to configure and grant achievements, then save them in the appropriate format. It also comes with limited in-game achievement viewer and toast notification implementations. Developers are welcome to use it out-of-the-box, though we also encourage custom viewers both in-game and as 3rd party on-device viewer apps.
+
+> [!NOTE]
+> If your game is not written in Lua you can still support Playdate Achievements. However, you'll need to reference the [schema](achievements.schema.json) and write your achievement data directly to the `/Shared` folder at the path `/Shared/Achievements/[gameID]`, using a unique ID for your game (such as its bundle ID).
 
 ## Documentation
-- [Using pd-achievements to manage your game's achievements](/docs/achievements.md)
-- [Reading and using other games' achievements in your game](/docs/crossgame.md)
-- [Display popups when the player earns an achievement](/docs/toasts.md)
-- [Show an interactive in-game achievement browser](/docs/viewer.md)
+
+- [Adding achievements to your game](/docs/achievements.md)
+- [Reading other games’ achievements](/docs/crossgame.md)
+- [Displaying popups for earned achievements](/docs/toasts.md)
+- [Showing an in-game achievements viewer](/docs/viewer.md)
 - [JSON Schema document for the output specification](achievements.schema.json)
 
-## Achievement Viewers
-`pd-achievements` aims to create a standard data format to manage game achievements. While it provides some limited in-game achievement browsing functions, developers are encouraged to create their own achievement clients that read the data saved to `/Shared`.
+## Games
 
-Achievement clients:
+Check out the [official website](https://playdatesquad.github.io/pd-achievements/) for a list of known games which award Playdate Achievements and integrate with viewers that support the schema.
+
+## Achievement Viewers
+
+`pd-achievements` aims to create a standard data format for Playdate game achievements. While it provides limited in-game achievement browsing capabilities, developers are encouraged to create their own achievement clients that read the data saved to `/Shared`.
+
+**Available achievement clients:**
+
 - [Trophy Case](https://github.com/gurtt/trophy-case/)
 
 ## Support
+
 Join the [Playdate Squad Discord](https://discord.com/invite/zFKagQ2) and then navigate to the [Achievement Framework discussion post](https://discord.com/channels/675983554655551509/1213250459851292713). Feel free to ask questions if you get stuck during implementation!
 
 ## Contributing
+
 Add a new GitHub issue for feature requests or bug reports. Provide as much detail as possible. To contribute code to the repository, please fork this repository, make your changes, and create a new pull request back to the main repository for review.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check out the [official website](https://playdatesquad.github.io/pd-achievements
 
 ## Achievement Viewers
 
-`pd-achievements` aims to create a standard data format for Playdate game achievements. While it provides limited in-game achievement browsing capabilities, developers are encouraged to create their own achievement clients that read the data saved to `/Shared`.
+`pd-achievements` aims to create a standard data format for Playdate game achievements. While it provides limited in-game achievement browsing capabilities, developers are encouraged to create their own achievement clients that read the data saved to `/Shared/Achievements/`.
 
 **Available achievement clients:**
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ This repository provides two things:
 1. **Achievements Schema:** A [schema](achievements.schema.json) describing the open Playdate Achievements data storage format which _any_ game may use to adopt the standard.
 2. **Lua Achievements Library:** A Lua library that games may use to implement the schema, along with UI niceties for displaying toast notifications and an in-game achievements viewer.
 
-The Lua library makes it easy to support playdate achievements in your games, providing APIs to configure and grant achievements, then save them in the appropriate format. It also comes with limited in-game achievement viewer and toast notification implementations. Developers are welcome to use it out-of-the-box, though we also encourage custom viewers both in-game and as 3rd party on-device viewer apps.
+The included Lua reference library provides three components:
+- An achievements management system for creating, unlocking, and saving achievements.
+- An in-game viewer to show achievements in your game.
+- A notification system for showing toasts when players unlock achievements in your game.
+
+All of these components are optional—you can implement or omit any of these in the way that works best for your game.
 
 > [!NOTE]
 > If your game is not written in Lua you can still support Playdate Achievements. However, you'll need to reference the [schema](achievements.schema.json) and write your achievement data directly to the `/Shared` folder at the path `/Shared/Achievements/[gameID]/Achievements.json`, using a unique ID for your game (such as its bundle ID).


### PR DESCRIPTION
I started out with a goal of removing the link to the outdated draft spec and the reference to an "in development" standard, and wound up with a slightly more substantial update to the main README. I think this improves clarity for both Lua and non-Lua devs regarding what's provided in the repo and how to take advantage of it.

Fixes #36 