### PR TITLE
Add $id field to schema for forwards compatibility

### DIFF
--- a/achievements.schema.json
+++ b/achievements.schema.json
@@ -15,8 +15,8 @@
 	],
 	"properties": {
 		"specVersion": {
-			"const": "v1.0.0",
-			"description": "The specification version this data is based on. This field defines this data file as following schema ID `https://github.com/playdatesquad/pd-achievements/blob/<specVersion>/achievements.schema.json`"
+			"const": "1.0.0",
+			"description": "The specification version this data is based on. This field defines this data file as following schema ID `https://github.com/playdatesquad/pd-achievements/blob/v<specVersion>/achievements.schema.json`"
 		},
 		"gameID": {
 			"type": "string",

--- a/achievements.schema.json
+++ b/achievements.schema.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://github.com/playdatesquad/pd-achievements/blob/v1.0.0/achievements.schema.json",
 	"type": "object",
 	"title": "Playdate Squad Achievements Schema",
 	"description": "The necessary structure for a game's achievements.json file.",
@@ -13,6 +14,10 @@
 		"achievements"
 	],
 	"properties": {
+		"specVersion": {
+			"const": "v1.0.0",
+			"description": "The specification version this data is based on. This field defines this data file as following schema ID `https://github.com/playdatesquad/pd-achievements/blob/<specVersion>/achievements.schema.json`"
+		},
 		"gameID": {
 			"type": "string",
 			"description": "Bundle identifier for your game."
@@ -40,10 +45,6 @@
 		"cardPath": {
 			"type": "string",
 			"description": "Path to a 380x90 .pdi image to use as your game's card art, relative to this file. Doesn't support transparency."
-		},
-		"specVersion": {
-			"type": "string",
-			"description": "The specification version this data is based on in semver."
 		},
 		"achievements": {
 			"type": "array",

--- a/achievements/achievements.lua
+++ b/achievements/achievements.lua
@@ -60,7 +60,7 @@ local shared_images_updated_file <const> = "_last_seen_version.txt"
 
 ---@diagnostic disable-next-line: lowercase-global
 achievements = {
-	specVersion = "1.0",
+	specVersion = "v1.0.0",
 	flag_is_playdatesquad_api = true,
 
 	forceSaveOnGrantOrRevoke = false,

--- a/achievements/achievements.lua
+++ b/achievements/achievements.lua
@@ -60,7 +60,7 @@ local shared_images_updated_file <const> = "_last_seen_version.txt"
 
 ---@diagnostic disable-next-line: lowercase-global
 achievements = {
-	specVersion = "v1.0.0",
+	specVersion = "1.0.0",
 	flag_is_playdatesquad_api = true,
 
 	forceSaveOnGrantOrRevoke = false,


### PR DESCRIPTION
The changes herein would become valid as soon as a release tag "v1.0.0" is created. In the future, changes to the schema definition must update the `$id` property, the value of the `specVersion` const, and the value of `achievements.specVersion` in the internal library and be paired with a GitHub tag matching the new version string.