### PR TITLE
Sort games descending by date, by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It’s all about the games. Here’s a (non-comprehensive) list of games that aw
 
 <div class="game-grid grid">
 
-{% assign sortedGames = site.data.games | sort: 'title' %}
+{% assign sortedGames = site.data.games | sort: 'releaseDate', 'first' | reverse %}
 {% for game in sortedGames %}
 
 <div class="game" data-release-date="{{ game.releaseDate }}" data-last-added-date="{{ game.lastAddedDate | default: game.releaseDate }}" data-title="{{ game.title }}" data-author="{{ game.author }}" data-achievement-count="{{ game.achievementCount | default: 0 }}">

--- a/assets/scripts/sort.js
+++ b/assets/scripts/sort.js
@@ -1,10 +1,11 @@
 const sortContainerSelector = ".game-grid"; // Selector for the container of items to sort
 const filterBarSelector = "#filter-bar"; // Selector for target element of the sort and filter controls
 const toggleButtonClass = "toggle"; // Class name applied to the sort direction toggle element
+const defaultSort = "sortByDate"; // The default sort option
 
 let sort = {
-  direction: 1, // ascending
-  sortFn: "sortByTitle", // default implemented via liquid in README.md
+  direction: -1, // descending
+  sortFn: defaultSort,
 
   init: function () {
     const searchInput = document.createElement("input");
@@ -32,10 +33,10 @@ let sort = {
     const select = document.createElement("select");
 
     const options = [
+      { value: "sortByDate", label: "Date" }, // default comes first
       { value: "sortByTitle", label: "Title" },
       { value: "sortByAuthor", label: "Author" },
       { value: "sortByCount", label: "Achievements" },
-      { value: "sortByDate", label: "Date" },
     ];
 
     options.forEach((option) => {
@@ -51,7 +52,7 @@ let sort = {
     });
 
     const arrow = document.createElement("a");
-    arrow.textContent = "↑";
+    arrow.textContent = "↓"; // descending
     arrow.classList.add(toggleButtonClass);
 
     arrow.addEventListener("click", (event) => {
@@ -68,6 +69,9 @@ let sort = {
     const filterBar = document.querySelector(filterBarSelector);
     filterBar.appendChild(searchInput);
     filterBar.appendChild(sortSelect);
+
+    // apply the intended default to the items on the page
+    sort[sort.sortFn]();
   },
 
   sortByTitle: function () {


### PR DESCRIPTION
Jekyll doesn't enable sorting collections based on complex logic involving multiple properties. For this reason, the "native" default ordering of games on the page is now descending by release date (replacing ascending by title). If JS is enabled, then the more capable sort method which takes both release date and last updated date into account overrides that default. This happens fast enough that few if any will notice.

TLDR:
* Without JS: Sort descending by release date (with no option to change)
* With JS: Sort descending by more recent of release date and last added date