### PR TITLE
[fix] typo in m variable that prevents returnToGameFuncton to be call…

### DIFF
--- a/achievements/viewer.lua
+++ b/achievements/viewer.lua
@@ -1120,7 +1120,7 @@ function av.animateOutUpdate()
       end
       av.restoreUserSettings()
       playdate.getCrankTicks(1)
-      local returnFunction = m.returnToGameFunction
+      local returnFunction = m.returnToGame
       av.destroy()
       if returnFunction then returnFunction() end
    end


### PR DESCRIPTION
…ed, fixes #73

Typo at line #1123 

```
local returnFunction = m.returnToGameFunction
```

mismatch init at line #1312 of viewer.lua

```
m.returnToGame = config.returnToGameFunction or function() end
```

thus preventing `returnToGameFunction to be called.