### PR TITLE
[improve] add version number to each module

### DIFF
--- a/achievements/achievements.lua
+++ b/achievements/achievements.lua
@@ -48,6 +48,10 @@ achievements = {
 
 	--- Whether to save game data immediately when granting or revoking an achievement.
 	forceSaveOnGrantOrRevoke = false,
+
+	--version number of this module
+	versionNumber = "1.0.0",
+
 	paths = {},
 }
 

--- a/achievements/crossgame.lua
+++ b/achievements/crossgame.lua
@@ -12,7 +12,10 @@ if not (achievements and achievements.flag_is_playdatesquad_api) then
 	error("Achievements 'crossgame' module must be loaded after the base PlaydateSquad achievement library.")
 end
 
-local crossgame = {}
+local crossgame = {
+	--version number of this module
+	versionNumber = "1.0.0"
+}
 local gfx <const> = playdate.graphics
 achievements.crossgame = crossgame
 

--- a/achievements/toasts.lua
+++ b/achievements/toasts.lua
@@ -1020,5 +1020,7 @@ achievements.toasts = {
 
    manualUpdate = at.updateToast,
 
+   --version number of this module
+   versionNumber = "1.0.0",
    getCache = function() return persistentCache end,
 }

--- a/achievements/viewer.lua
+++ b/achievements/viewer.lua
@@ -1365,6 +1365,7 @@ achievements.viewer = {
    forceExit = av.forceExit,
    hasLaunched = av.hasLaunched,
    setVolume = av.setVolume,
-
+   --version number of this module
+   versionNumber = "1.0.0",
    getCache = function() return persistentCache end,
 }

--- a/docs/achievements.md
+++ b/docs/achievements.md
@@ -117,6 +117,14 @@ achievements.forceSaveOnGrantOrRevoke = true -- Defaults to false. Only set if y
 
 ### Properties
 
+#### `string` achievements.specVersion
+
+Same as achievements.schema.json→specVersion.
+
+#### `string` achievements.versionNumber
+
+Version number of this module, different from specVersion as it tracks achievements.schema.json→specVersion.
+
 #### `bool` achievements.forceSaveOnGrantOrRevoke
 
 If this flag is set to `true` then achievements will be saved to disk every time an achievement is newly granted or revoked. Defaults to `false`.

--- a/docs/crossgame.md
+++ b/docs/crossgame.md
@@ -27,6 +27,12 @@ end
 
 ## API Reference
 
+### Properties
+
+#### `string` achievements.crossgame.versionNumber
+
+Version number of this module.
+
 ### Functions
 
 #### achievements.crossgame.gamePlayed(`string`: _game_id_)

--- a/docs/toasts.md
+++ b/docs/toasts.md
@@ -72,6 +72,12 @@ achievements.grant("my_achievement") -- shows a toast!
 
 ## API Reference
 
+### Properties
+
+#### `string` achievements.toasts.versionNumber
+
+Version number of this module.
+
 ### Functions
 
 #### achievements.toasts.initialize(`table?`: _config_)

--- a/docs/viewer.md
+++ b/docs/viewer.md
@@ -64,6 +64,12 @@ achievements.viewer.launch()
 
 ## API Reference
 
+### Properties
+
+#### `string` achievements.viewer.versionNumber
+
+Version number of this module.
+
 ### Functions
 
 #### achievements.viewer.initialize(`table?`: _config_)


### PR DESCRIPTION
With the new introduced properties it's now possible to fine track which version of the module you bundled in your game project.

What keeps me uncertain about this, it's the fact that one user may pick code from the repo at anytime without these properties being updated..

On the other hand, these properties may be good if at fixed milestones before publishing a GitHub release code maintainer update each `versionNumber` of module that has changes.

fixes #71