### PR TITLE
Sort based on badge group

### DIFF
--- a/assets/scripts/badges.js
+++ b/assets/scripts/badges.js
@@ -16,12 +16,18 @@ let badges = {
       const now = new Date();
       if (releaseDate && now < releaseDate) {
         g.classList.add("badged", "badge-soon");
+        g.dataset.badgeGroup = 5;
       } else if (lastAddedDate && now < lastAddedDate) {
         g.classList.add("badged", "badge-soon-released");
+        g.dataset.badgeGroup = 4;
       } else if (releaseDate && now < releaseDate.addDays(newBadgeDays)) {
         g.classList.add("badged", "badge-new");
+        g.dataset.badgeGroup = 1;
       } else if (lastAddedDate && now < lastAddedDate.addDays(moreBadgeDays)) {
         g.classList.add("badged", "badge-more");
+        g.dataset.badgeGroup = 2;
+      } else {
+        g.dataset.badgeGroup = 3;
       }
     });
   },

--- a/assets/scripts/sort.js
+++ b/assets/scripts/sort.js
@@ -1,10 +1,11 @@
 const sortContainerSelector = ".game-grid"; // Selector for the container of items to sort
 const filterBarSelector = "#filter-bar"; // Selector for target element of the sort and filter controls
 const toggleButtonClass = "toggle"; // Class name applied to the sort direction toggle element
+const defaultSort = "sortByDate"; // The default sort option
 
 let sort = {
-  direction: 1, // ascending
-  sortFn: "sortByTitle", // default implemented via liquid in README.md
+  direction: -1, // descending
+  sortFn: defaultSort,
 
   init: function () {
     const searchInput = document.createElement("input");
@@ -32,10 +33,10 @@ let sort = {
     const select = document.createElement("select");
 
     const options = [
+      { value: "sortByDate", label: "Date" }, // default comes first
       { value: "sortByTitle", label: "Title" },
       { value: "sortByAuthor", label: "Author" },
       { value: "sortByCount", label: "Achievements" },
-      { value: "sortByDate", label: "Date" },
     ];
 
     options.forEach((option) => {
@@ -51,7 +52,7 @@ let sort = {
     });
 
     const arrow = document.createElement("a");
-    arrow.textContent = "↑";
+    arrow.textContent = "↓"; // descending
     arrow.classList.add(toggleButtonClass);
 
     arrow.addEventListener("click", (event) => {
@@ -68,6 +69,9 @@ let sort = {
     const filterBar = document.querySelector(filterBarSelector);
     filterBar.appendChild(searchInput);
     filterBar.appendChild(sortSelect);
+
+    // apply the intended default to the items on the page
+    sort[sort.sortFn]();
   },
 
   sortByTitle: function () {


### PR DESCRIPTION
The gist of the new "Default"  sort logic is…
1. Sort first by "badge group", in the order: New, More, (None), Soon*, Soon!
2. Sort cards within in New/More/(None) groups descending by lastAddedDate (falling back to releaseDate)—in other words, most recently released/udpated first
3. Sort cards within Soon*/Soon! groups ascending by future release date—in other words, soonest planned to release first
