### PR TITLE
Update toasts.lua

### DIFF
--- a/achievements/toasts.lua
+++ b/achievements/toasts.lua
@@ -900,6 +900,7 @@ function at.toast(achievementId, config)
             m.toastSprite = gfx.sprite.new()
             m.toastSprite.update = at.updateToast
             m.toastSprite:setUpdatesEnabled(true)
+            m.toastSprite:setIgnoresDrawOffset(true)
             m.toastSprite:add()
 
             if originalSpriteRemoveAllFunction == nil then


### PR DESCRIPTION
Sets ignoredrawoffset to true for sprite render so toasts don't appear off screen.