### PR TITLE
Fixes a badge layout error when the game title text is truncated.

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -224,7 +224,7 @@ body {
     margin: 2em 0;
     display: grid;
     gap: 48px;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
 
     @media screen and (max-width: $tablet) {
       grid-template-columns: auto;
@@ -236,6 +236,11 @@ body {
     .game {
       display: inline-block;
       line-height: 1.5em;
+      max-width: min(
+        100%,
+        calc(var(--game-banner-width) + var(--game-banner-border-weight) * 2)
+      );
+      min-width: 0;
 
       img {
         display: block;
@@ -246,9 +251,8 @@ body {
         border-radius: var(--game-banner-border-radius);
         box-sizing: border-box;
         margin-bottom: 0.5em;
-        width: calc(
-          var(--game-banner-width) + var(--game-banner-border-weight) * 2
-        );
+        width: 100%;
+        max-width: 100%;
         height: auto;
       }
       a,
@@ -256,6 +260,7 @@ body {
       a:active,
       a:visited {
         display: inline-block;
+        max-width: 100%;
         color: var(--font-color);
         text-decoration: none;
         img {
@@ -292,6 +297,7 @@ body {
       .title {
         color: var(--font-color);
         font-weight: bold;
+        font-size: 0.9em;
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
@@ -299,6 +305,7 @@ body {
       .author {
         color: var(--dimmed-font-color);
         line-height: 1em;
+        font-size: 0.9em;
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;


### PR DESCRIPTION
This fixes the grid sizing so that the columns remain equal width, as well as the banner size to guarantee that the corner badges are properly aligned to it even when long game titles/author text gets truncated. I also decreased the size of that text slightly to reduce the likelihood of truncation, since it was quite generous before.